### PR TITLE
Add additional error handling to applyGuard's Patient resolve.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -192,7 +192,7 @@ function applyGuard(appliableResource, patientReference=null, resolver=null, aux
 
   // Try to resolve the patient reference
   let Patient = resolver(patientReference);
-  if (!Patient || Patient?.length == 0) throw new Error('Patient reference cannot be resolved');
+  if (!Patient || Patient?.length == 0 || !Patient[0]) throw new Error('Patient reference cannot be resolved');
   Patient = Patient[0];
 
   return Patient;


### PR DESCRIPTION
In the case that `Patient` ends up equating to `[ undefined ]`, the error doesn't fire, since `Patient?.length == 0` isn't `true` when the only entry is `undefined`.

Addition of ` || !Patient[0]` solves this and the error fires as intended. 

Worth noting that this is likely an edge case and the result of egregious misuse on my part. This, at the very least, saves a minute or two for the next person that does something wonky.