### PR TITLE
Support for running in a non-Node.js environment

### DIFF
--- a/src/simpleResolver.js
+++ b/src/simpleResolver.js
@@ -115,6 +115,12 @@ function compareSemver(a,b) {
   // If either a or b do not have a version element, set a default.
   const aVersion = a.version ?? '0.0.0';
   const bVersion = b.version ?? '0.0.0';
+  if (aVersion.split('.').length < 3) {
+    aVersion = coerce(aVersion)?.raw || '0.0.0';
+  }
+  if (bVersion.split('.').length < 3) {
+    bVersion = coerce(bVersion)?.raw || '0.0.0';
+  }
 
   return rcompare(aVersion, bVersion);
 }

--- a/src/simpleResolver.js
+++ b/src/simpleResolver.js
@@ -42,6 +42,9 @@ export function simpleResolver(input = null) {
     // Is this a bundle?
     if (fhirJson?.resourceType == 'Bundle') {
       // Flatten out the entries
+      fhirJson = fhirJson.entry !== undefined ?
+        fhirJson.entry.map(r => r.resource) :
+        [];
       fhirJson = fhirJson?.entry.map(r => r.resource);
     } else if (fhirJson.resourceType) {
       // Is this even a FHIR resource?

--- a/src/simpleResolver.js
+++ b/src/simpleResolver.js
@@ -15,14 +15,15 @@ const restfulFhirUrlRegex = /((http|https):\/\/([A-Za-z0-9\-\\\.\:\%\$]*\/)+)?(A
  * @param {string|object|array} input 
  * @returns {function}
  */
-export function simpleResolver(input = null) {
+export function simpleResolver(input = null, isNodeJs=true) {
 
   let fhirJson;
 
   // First check if the input is a string
   if (typeof input ==  'string') {
     // Then check whether this string is a path that exists
-    if (existsSync(input)) {
+    //  (only if we're running in Node.js since we need filesystem access)
+    if (isNodeJs && existsSync(input)) {
       // If it is, then read it in an deserialize
       fhirJson = JSON.parse(readFileSync(input));
     } else {

--- a/src/simpleResolver.js
+++ b/src/simpleResolver.js
@@ -89,7 +89,8 @@ export function simpleResolver(input = null) {
             && (rsrc.id == resourceId || rsrc.url == url);
         }).sort(compareSemver); 
         // NOTE: We're grabbing the first index which should be latest version.
-        resolvedReference = [sortedFhirJson.shift()];
+        const shifted = sortedFhirJson.shift();
+        resolvedReference = shifted !== undefined ? [shifted] : [];
       }
     } else { // No reference provided so just return fhirJson in its entirety.
       resolvedReference = fhirJson;

--- a/src/utils.js
+++ b/src/utils.js
@@ -170,6 +170,24 @@ export function expandPathAndValue(path, value) {
   return expandedObject;
 }
 
+/**
+ * @param {object (FHIR Library)} library - FHIR Library to search in
+ * @param {boolean} isNodeJs - True if running in Node.JS
+ * @returns {object | undefined} - Parsed ELM JSON, if it exists
+ */
+ export function getElmJsonFromLibrary(library, isNodeJs=true) {
+  for (const libraryContent of library.content) {
+    if (libraryContent.contentType == "application/elm+json") {
+      if (isNodeJs) {
+        return JSON.parse(Buffer.from(libraryContent.data,'base64').toString('ascii'));
+      }
+      else {
+        return JSON.parse(window.atob(libraryContent.data)); // TODO: Throw error on no data
+      }
+    }
+  }
+}
+
 // From: https://www.hl7.org/fhir/choice-elements.json
 const publishedFhirChoiceTypes = {
   "elements" : {


### PR DESCRIPTION
Running outside of Node.js requires Web Workers to be defined at `window.Worker`, and it currently expects to find a worker script at "./cql.worker.js". Maybe it would be better to pass the worker script URL/path as an optional parameter to applyPlan?

This has only been tested using Webpack 5 btw, but let me know if you'd like to see that config file as well

`src/main.js:9` is messy, but I had no particular reason against using an "if" there, just preference. We just need to avoid running those functions when not in Node

I also threw in a couple bug fixes for some problems we ran into