### PR TITLE
Copy CQF-Ruler behaviour when creating a target resource from an ActivityDefinition apply

### DIFF
--- a/test/fixtures/activityResources.json
+++ b/test/fixtures/activityResources.json
@@ -39,5 +39,164 @@
       ],
       "text": "I'm nothing"
     }
+  },
+  {
+    "resourceType": "ActivityDefinition",
+    "id": "kindIsServiceRequest",
+    "status": "draft",
+    "url": "https://example-fhir-api.com/path/to/fhir/api/ActivityDefinition/kindIsServiceRequest",
+    "kind": "ServiceRequest",
+    "code": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "260385009",
+          "display": "Negative"
+        }
+      ],
+      "text": "I'm nothing"
+    },
+    "intent": "proposal",
+    "bodySite": [
+      {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "260385009",
+            "display": "Negative"
+          }
+        ],
+        "text": "I'm nothing"
+      }
+    ]
+  },
+  {
+    "resourceType": "ActivityDefinition",
+    "id": "kindIsMedicationRequest",
+    "status": "draft",
+    "url": "https://example-fhir-api.com/path/to/fhir/api/ActivityDefinition/kindIsMedicationRequest",
+    "kind": "MedicationRequest",
+    "priority": "routine",
+    "productCodeableConcept": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "260385009",
+          "display": "Negative"
+        }
+      ],
+      "text": "I'm nothing"
+    },
+    "dosage": [
+      {
+        "sequence" : 1,
+        "text" : "First sequence dosage"
+      },
+      {
+        "sequence" : 2,
+        "text" : "Second sequence dosage"
+      }
+    ]
+  },
+  {
+    "resourceType": "ActivityDefinition",
+    "id": "kindIsSupplyRequest",
+    "status": "draft",
+    "url": "https://example-fhir-api.com/path/to/fhir/api/ActivityDefinition/kindIsSupplyRequest",
+    "kind": "SupplyRequest",
+    "code": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "260385009",
+          "display": "Negative"
+        }
+      ],
+      "text": "I'm nothing"
+    },
+    "quantity": {
+      "value": "0"
+    }
+  },
+  {
+    "resourceType": "ActivityDefinition",
+    "id": "kindIsCommunicationRequest",
+    "status": "draft",
+    "url": "https://example-fhir-api.com/path/to/fhir/api/ActivityDefinition/kindIsCommunicationRequest",
+    "kind": "CommunicationRequest",
+    "relatedArtifact": [
+      {
+        "type": "documentation",
+        "url": "https://example.com/exampleDocumentationSite.html",
+        "display": "Documentation"
+      },
+      {
+        "type": "justification",
+        "url": "https://example.com/exampleJustificationSite.html",
+        "display": "Justification"
+      }
+    ],
+    "code": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "260385009",
+          "display": "Negative"
+        }
+      ],
+      "text": "I'm nothing"
+    }
+  },
+  {
+    "resourceType": "ActivityDefinition",
+    "id": "kindIsTask",
+    "status": "draft",
+    "url": "https://example-fhir-api.com/path/to/fhir/api/ActivityDefinition/kindIsTask",
+    "kind": "Task",
+    "relatedArtifact": [
+      {
+        "type": "documentation",
+        "url": "https://example.com/exampleDocumentationSite.html",
+        "display": "Documentation"
+      },
+      {
+        "type": "justification",
+        "url": "https://example.com/exampleJustificationSite.html",
+        "display": "Justification"
+      }
+    ],
+    "code": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "260385009",
+          "display": "Negative"
+        }
+      ],
+      "text": "I'm nothing"
+    }
+  },
+  {
+    "resourceType": "ActivityDefinition",
+    "id": "kindIsTaskWithCpgCollectWith",
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-collectWith",
+        "valueCanonical": "https://example-fhir-api.com/path/to/fhir/api/exampleQuestionnaire"
+      }
+    ],
+    "status": "draft",
+    "url": "https://example-fhir-api.com/path/to/fhir/api/ActivityDefinition/kindIsTaskWithCpgCollectWith",
+    "kind": "Task",
+    "code": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "260385009",
+          "display": "Negative"
+        }
+      ],
+      "text": "I'm nothing"
+    }
   }
 ]

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -647,3 +647,117 @@ describe('Merge Nested Actions Tests', async function() {
   });
 
 });
+
+describe('ActivityDefinition.kind Tests', async function() {
+
+  it('Should copy over the correct structural elements for a ServiceRequest', async function() {
+    let resolver = simpleResolver('./test/fixtures/activityResources.json');
+    const serviceReqAD = resolver('ActivityDefinition/kindIsServiceRequest')[0];
+    const patientReference = 'Patient/1';
+
+    const targetResource = await applyActivity(serviceReqAD, patientReference, resolver);
+
+    targetResource.subject.reference.should.equal(patientReference);
+    targetResource.intent.should.equal(serviceReqAD.intent);
+    targetResource.code.should.deep.equal(serviceReqAD.code);
+    targetResource.bodySite.should.deep.equal(serviceReqAD.bodySite);
+
+  });
+
+  it('Should copy over the correct structural elements for a MedicationRequest', async function() {
+    let resolver = simpleResolver('./test/fixtures/activityResources.json');
+    const medicationReqAD = resolver('ActivityDefinition/kindIsMedicationRequest')[0];
+    const patientReference = 'Patient/1';
+
+    const targetResource = await applyActivity(medicationReqAD, patientReference, resolver);
+
+    targetResource.priority.should.equal(medicationReqAD.priority);
+    targetResource.dosageInstruction.should.deep.equal(medicationReqAD.dosage);
+    targetResource.medicationCodeableConcept.should.deep.equal(medicationReqAD.productCodeableConcept);
+
+  });
+
+  it('Should copy over the correct structural elements for a SupplyRequest', async function() {
+    let resolver = simpleResolver('./test/fixtures/activityResources.json');
+    const supplyReqAD = resolver('ActivityDefinition/kindIsSupplyRequest')[0];
+    const patientReference = 'Patient/1';
+
+    const targetResource = await applyActivity(supplyReqAD, patientReference, resolver);
+
+    targetResource.quantity.should.deep.equal(supplyReqAD.quantity);
+    targetResource.itemCodeableConcept.should.deep.equal(supplyReqAD.code);
+
+  });
+
+  it('Should copy over the correct structural elements for a CommunicationRequest', async function() {
+    let resolver = simpleResolver('./test/fixtures/activityResources.json');
+    const communicationReqAD = resolver('ActivityDefinition/kindIsCommunicationRequest')[0];
+    const patientReference = 'Patient/1';
+
+    const targetResource = await applyActivity(communicationReqAD, patientReference, resolver);
+
+    targetResource.payload.should.have.deep.members([
+      {
+        "contentString": "I'm nothing"
+      },
+      {
+        "contentAttachment": {
+            "url": "https://example.com/exampleDocumentationSite.html",
+            "title": "Documentation"
+        }
+      },
+      {
+        "contentAttachment": {
+            "url": "https://example.com/exampleJustificationSite.html",
+            "title": "Justification"
+        }
+      }
+    ]);
+
+  });
+
+  it('Should copy over the correct structural elements for a Task', async function() {
+    let resolver = simpleResolver('./test/fixtures/activityResources.json');
+    const taskAD = resolver('ActivityDefinition/kindIsTask')[0];
+    const patientReference = 'Patient/1';
+
+    const targetResource = await applyActivity(taskAD, patientReference, resolver);
+
+    targetResource.for.reference.should.equal(patientReference);
+    targetResource.input.should.have.deep.members([
+      {
+        "type": taskAD.code,
+        "valueAttachment": {
+          "url": "https://example.com/exampleDocumentationSite.html",
+          "title": "Documentation"
+        }
+      },
+      {
+        "type": taskAD.code,
+        "valueAttachment": {
+          "url": "https://example.com/exampleJustificationSite.html",
+          "title": "Justification"
+        }
+      },
+    ]);
+
+  });
+
+  it('Should copy over the correct structural elements for a Task with a cpg-collectwith extension', async function() {
+    let resolver = simpleResolver('./test/fixtures/activityResources.json');
+    const taskAD = resolver('ActivityDefinition/kindIsTaskWithCpgCollectWith')[0];
+    const patientReference = 'Patient/1';
+
+    const targetResource = await applyActivity(taskAD, patientReference, resolver);
+
+    targetResource.for.reference.should.equal(patientReference);
+    targetResource.input.should.have.deep.members([
+      {
+        "type": taskAD.code,
+        "valueCanonical": "https://example-fhir-api.com/path/to/fhir/api/exampleQuestionnaire"
+      }
+    ]);
+
+  });
+
+});


### PR DESCRIPTION
This PR removes a few cases where the resulting target resource from Encender would include an element that should not exist on that resource. For instance, a resulting ServiceRequest should not have a dosage element

The default case may still create invalid resources, however

Element choices were adapted from [CQF-Ruler](https://github.com/DBCG/cqf-ruler/blob/v0.6.0/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/r4/provider/ActivityDefinitionApplyProvider.java). Happy to make any changes!