### PR TITLE
Update cql-worker dependency

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,0 +1,3 @@
+# 0.7.1
+
+Update cql-worder dependency to 1.1.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "encender",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "encender",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
-        "cql-worker": "^1.1.6",
+        "cql-worker": "^1.1.7",
         "semver": "^6.3.0"
       },
       "devDependencies": {
@@ -356,21 +356,22 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.4.0.tgz",
-      "integrity": "sha512-XgjoPnn3IFys2t2wwi7aT5sXsS+h7/CvqI7dtdDQtSsiK6ePCfnWPT4CRuapiiW3OBrPvqD1oYmvy6X2xvvMlA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/cql-worker": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.6.tgz",
-      "integrity": "sha512-J1QEk23Zd8WQeFp01bWwI+Uc4VwERr2GyCCSzqFnYoAGXVaDygmXw1D6c90nuvBeRNtazYkzybx0dyRzjMn36A==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.7.tgz",
+      "integrity": "sha512-wSjavK9yyhaqa4VGO8QcTZJuw5lN7bk3kYscbTt9xHJdudczIY8rQS967eyBsTba1lGrjsN9uKAFAPqPd4RuoA==",
       "dependencies": {
         "cql-exec-fhir": "^2.1.4",
-        "cql-execution": "^2.4.0"
+        "cql-execution": "^3.0.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -634,6 +635,11 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/immutable": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -1957,21 +1963,22 @@
       }
     },
     "cql-execution": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.4.0.tgz",
-      "integrity": "sha512-XgjoPnn3IFys2t2wwi7aT5sXsS+h7/CvqI7dtdDQtSsiK6ePCfnWPT4CRuapiiW3OBrPvqD1oYmvy6X2xvvMlA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "cql-worker": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.6.tgz",
-      "integrity": "sha512-J1QEk23Zd8WQeFp01bWwI+Uc4VwERr2GyCCSzqFnYoAGXVaDygmXw1D6c90nuvBeRNtazYkzybx0dyRzjMn36A==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.7.tgz",
+      "integrity": "sha512-wSjavK9yyhaqa4VGO8QcTZJuw5lN7bk3kYscbTt9xHJdudczIY8rQS967eyBsTba1lGrjsN9uKAFAPqPd4RuoA==",
       "requires": {
         "cql-exec-fhir": "^2.1.4",
-        "cql-execution": "^2.4.0"
+        "cql-execution": "^3.0.1"
       }
     },
     "cross-spawn": {
@@ -2166,6 +2173,11 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "immutable": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "encender",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "description": "An asynchronous implementation of the FHIR $apply operation",
   "main": "./src/main.js",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
-    "cql-worker": "^1.1.6",
+    "cql-worker": "^1.1.7",
     "semver": "^6.3.0"
   }
 }


### PR DESCRIPTION
### Summary:
Update cql-worker dependency to 1.1.7

### Test: 
Run `npm test` and all unit tests shall pass
