### PR TITLE
Remove reference to window so can run in Web Worker

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -70,7 +70,7 @@ export function parseName(names) {
         return JSON.parse(Buffer.from(libraryContent.data,'base64').toString('ascii'));
       }
       else {
-        return JSON.parse(window.atob(libraryContent.data)); // TODO: Throw error on no data
+        return JSON.parse(atob(libraryContent.data)); // TODO: Throw error on no data
       }
     }
   }


### PR DESCRIPTION
If encender is imported into a web worker, the getElmJsonFromLibrary function will throw an error because it references `window.atob` and the `window` scope is not present in web workers. `WorkerGlobalScope` does have an `atob` method. 